### PR TITLE
Update 4-relational-pseudo-class.json

### DIFF
--- a/4-relational-pseudo-class.json
+++ b/4-relational-pseudo-class.json
@@ -21,7 +21,7 @@
             "Safari": "15.4",
             "Edge": "105",
             "Internet Explorer": false,
-            "Opera": false
+            "Opera": "72"
         }
     },
     "codepen_identifier": "dRBLaK",


### PR DESCRIPTION
Opera 72 for Android released at 18 October 2022 added support has (updated chromium dependencies to 106).

> https://www.apkmirror.com/apk/opera-software-asa/opera/opera-72-0-3767-68191-release/

A little harder will be update "Can I use" (may need update almost all tables from 64 to 72 https://github.com/Fyrd/caniuse/issues/5602#issuecomment-792385127) and mdm tables (page recommend open Issue "[Report problems with this compatibility data on GitHub](https://github.com/mdn/browser-compat-data/issues/new?mdn-url=https%3A%2F%2Fdeveloper.mozilla.org%2Fen-US%2Fdocs%2FWeb%2FCSS%2F%3Ahas&metadata=%3C%21--+Do+not+make+changes+below+this+line+--%3E%0A%3Cdetails%3E%0A%3Csummary%3EMDN+page+report+details%3C%2Fsummary%3E%0A%0A*+Query%3A+%60css.selectors.has%60%0A*+Report+started%3A+2022-10-20T20%3A30%3A27.489Z%0A%0A%3C%2Fdetails%3E&title=css.selectors.has+-+%3CSUMMARIZE+THE+PROBLEM%3E&template=data-problem.yml)") tables.

---

In test I excluded projects like:

- Opera Mini without Exterme compression
- Opera Touch
- Opera Crypto Browser (https://play.google.com/store/apps/details?id=com.opera.cryptobrowser)

due uses Chrome WebView (his number then means nothing), and on iOS (uses Safari engine).