### PR TITLE
Update `4-relational-pseudo-class.json` &  `4-structural-pseudo-class.json`

### DIFF
--- a/4-relational-pseudo-class.json
+++ b/4-relational-pseudo-class.json
@@ -9,7 +9,7 @@
     "browser_support": {
         "Desktop": {
             "Chrome": "105",
-            "Firefox": false,
+            "Firefox": "121",
             "Safari": "15.4",
             "Edge": "105",
             "Internet Explorer": false,
@@ -17,7 +17,7 @@
         },
         "Mobile": {
             "Chrome": "105",
-            "Firefox": false,
+            "Firefox": "121",
             "Safari": "15.4",
             "Edge": "105",
             "Internet Explorer": false,

--- a/4-structural-pseudo-class.json
+++ b/4-structural-pseudo-class.json
@@ -4,24 +4,24 @@
     "name": "Structural pseudo-class",
     "description": "The pseudo-class **structural** introduces the `:nth-child()` and `:nth-last-child()` selector which is similar to the [`:nth-child()`](https://css4-selectors.com/selector/css3/structural-pseudo-class/#nth-child 'CSS3: Structural Pseudo Class') in CSS3. The difference is that this selector will match the given selector list composed of their [inclusive siblings](https://dom.spec.whatwg.org/#concept-tree-inclusive-sibling 'WHATWG: DOM Specification').",
     "statistics_regex": ":nth-child\\s*\\((.*)\\s+of\\s+(.*)\\)",
-    "example": ":nth-child()",
+    "example": ":nth-child(1 of s1, s2)",
     "example_description": "Every even list element should have a yellow background color even though some elements are hidden in between. The last `li` should have a green background color.",
     "browser_support": {
         "Desktop": {
-            "Chrome": false,
-            "Firefox": false,
+            "Chrome": "111",
+            "Firefox": "113",
             "Safari": "9",
-            "Edge": false,
+            "Edge": "111",
             "Internet Explorer": false,
-            "Opera": false
+            "Opera": "98"
         },
         "Mobile": {
-            "Chrome": false,
-            "Firefox": false,
+            "Chrome": "111",
+            "Firefox": "113",
             "Safari": "9",
-            "Edge": false,
+            "Edge": "111",
             "Internet Explorer": false,
-            "Opera": false
+            "Opera": "75"
         }
     },
     "codepen_identifier": "BZgEMg",


### PR DESCRIPTION
https://caniuse.com/css-nth-child-of

Opera Mobile looks as 75: https://www.apkmirror.com/apk/opera-software-asa/opera/opera-75-3-3978-72666-release/

> More changes/additions:
> - **Chromium 112**

Due 74 looks as powered on [Chromium 110](https://www.apkmirror.com/apk/opera-software-asa/opera/opera-74-3-3922-71982-release/).


---

Also somebody may need looks on test (if https://github.com/CSS4-Selectors/website/pull/10/commits/bffc137ae9867154f6a0efb068d12319290d82da didn't fix problem): https://css4-selectors.com/browser-selector-test/

![obraz](https://github.com/CSS4-Selectors/website/assets/35370833/bdaa39dc-f156-4be9-8286-5051531ddde7)

Test fails too on iOS Safari 15.6+, so change are needed. 